### PR TITLE
Minor change to allow 10/20 minutes past/to the hour (Eng)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,15 +77,15 @@
     <string-array name="Prefixes">
         <item/>
         <item/>
-        <item>a\u00A0quarter past</item>
+        <item>roughtly ten past</item>
         <item>a quarter past</item>
-        <item>almost\u00A0half past</item>
+        <item>about twenty past</item>
         <item>around\u00A0half past</item>
         <item>half past</item>
         <item>half\u00A0past</item>
+        <item>around twenty to</item>
         <item>a quarter to</item>
-        <item>a quarter to</item>
-        <item>approaching</item>
+        <item>about ten minutes to</item>
         <item>almost</item>
     </string-array>
     <string-array name="Suffixes">


### PR DESCRIPTION
Some changes to lines 80, 82, 86, 88 allowing a nicer read of times at around 10 and 20 minutes past and to the hour. Only English I'm afraid.