### PR TITLE
Fix for Dutch translation

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -676,7 +676,7 @@
         <item />
         <item />
         <item />
-        <item>uur</item>
+        <item> uur</item>
     </string-array>
     <string-array name="WeekDaysNL">
         <item>Zo</item>


### PR DESCRIPTION
Fixed a suffix missing a space in the Dutch translation